### PR TITLE
Add diff display functionality using java-diff-utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,11 @@
             <version>3.27.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.java-diff-utils</groupId>
+            <artifactId>java-diff-utils</artifactId>
+            <version>4.12</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/src/main/java/io/github/yupd/business/YamlRepoUpdater.java
+++ b/src/main/java/io/github/yupd/business/YamlRepoUpdater.java
@@ -9,6 +9,7 @@ import io.github.yupd.infrastructure.utils.StringUtils;
 import io.github.yupd.infrastructure.utils.UniqueIdGenerator;
 import io.github.yupd.infrastructure.utils.IOUtils;
 import io.github.yupd.infrastructure.update.model.ContentUpdateCriteria;
+import io.github.yupd.infrastructure.diff.DiffService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -29,6 +30,9 @@ public class YamlRepoUpdater {
     @Inject
     UniqueIdGenerator uniqueIdGenerator;
 
+    @Inject
+    DiffService diffService;
+
     public YamlUpdateResult update(YamlRepoUpdaterParameter parameter) {
         GitConnector connector = gitConnectorFactory.create(parameter.getTargetGitFile().getRepository());
 
@@ -44,6 +48,9 @@ public class YamlRepoUpdater {
 
         LOGGER.debugf("New content:");
         LOGGER.debugf("%s", newContent);
+        
+        LOGGER.infof("Changes:");
+        LOGGER.infof("%s", diffService.generateDiff(oldContent, newContent));
 
         if (parameter.isDryRun()) {
             LOGGER.infof("No updates since the dry mode is activated");

--- a/src/main/java/io/github/yupd/infrastructure/diff/DiffService.java
+++ b/src/main/java/io/github/yupd/infrastructure/diff/DiffService.java
@@ -1,0 +1,33 @@
+package io.github.yupd.infrastructure.diff;
+
+import com.github.difflib.DiffUtils;
+import com.github.difflib.patch.Patch;
+import com.github.difflib.patch.AbstractDelta;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Arrays;
+import java.util.List;
+
+@ApplicationScoped
+public class DiffService {
+
+    public String generateDiff(String oldContent, String newContent) {
+        List<String> oldLines = Arrays.asList(oldContent.split(System.lineSeparator()));
+        List<String> newLines = Arrays.asList(newContent.split(System.lineSeparator()));
+        
+        Patch<String> patch = DiffUtils.diff(oldLines, newLines);
+        
+        if (patch.getDeltas().isEmpty()) {
+            return "No differences found";
+        }
+        
+        StringBuilder diff = new StringBuilder();
+        
+        for (AbstractDelta<String> delta : patch.getDeltas()) {
+            delta.getSource().getLines().forEach(line -> diff.append("- ").append(line).append(System.lineSeparator()));
+            delta.getTarget().getLines().forEach(line -> diff.append("+ ").append(line).append(System.lineSeparator()));
+        }
+        
+        return diff.toString().trim();
+    }
+}

--- a/src/test/java/io/github/yupd/business/YamlRepoUpdaterTest.java
+++ b/src/test/java/io/github/yupd/business/YamlRepoUpdaterTest.java
@@ -8,6 +8,7 @@ import io.github.yupd.infrastructure.update.ContentUpdateService;
 import io.github.yupd.infrastructure.utils.IOUtils;
 import io.github.yupd.infrastructure.utils.UniqueIdGenerator;
 import io.github.yupd.infrastructure.update.model.ContentUpdateCriteria;
+import io.github.yupd.infrastructure.diff.DiffService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,6 +46,9 @@ class YamlRepoUpdaterTest {
 
     @Mock
     private UniqueIdGenerator uniqueIdGenerator;
+
+    @Mock
+    private DiffService diffService;
 
     @InjectMocks
     private YamlRepoUpdater updater;

--- a/src/test/java/io/github/yupd/infrastructure/diff/DiffServiceTest.java
+++ b/src/test/java/io/github/yupd/infrastructure/diff/DiffServiceTest.java
@@ -1,0 +1,30 @@
+package io.github.yupd.infrastructure.diff;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DiffServiceTest {
+
+    private final DiffService diffService = new DiffService();
+
+    @Test
+    void shouldReturnNoDifferencesWhenContentsAreEqual() {
+        String content = "line1" + System.lineSeparator() + "line2";
+        
+        String result = diffService.generateDiff(content, content);
+        
+        assertThat(result).isEqualTo("No differences found");
+    }
+
+    @Test
+    void shouldReturnDiffWhenContentsAreDifferent() {
+        String oldContent = "old line";
+        String newContent = "new line";
+        
+        String result = diffService.generateDiff(oldContent, newContent);
+        
+        assertThat(result).isNotEmpty();
+        assertThat(result).isNotEqualTo("No differences found");
+    }
+}


### PR DESCRIPTION
## Summary
- Add java-diff-utils dependency to display file changes in a unified diff format
- Create dedicated DiffService for generating diff output with +/- notation
- Integrate diff logging in YamlRepoUpdater to show changes via LOGGER.infof
- Add unit tests with minimal coverage focusing on service behavior

## Test plan
- [x] Unit tests for DiffService pass
- [x] YamlRepoUpdater tests updated with DiffService mocking
- [x] Integration tests show diff output in logs
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)