### PR TITLE
Refactor ContentUpdateService to process updates in order

### DIFF
--- a/src/main/java/io/github/yupd/infrastructure/update/updator/RegexUpdator.java
+++ b/src/main/java/io/github/yupd/infrastructure/update/updator/RegexUpdator.java
@@ -3,23 +3,15 @@ package io.github.yupd.infrastructure.update.updator;
 import io.github.yupd.infrastructure.update.model.ContentUpdateCriteria;
 import jakarta.enterprise.context.ApplicationScoped;
 
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
 public class RegexUpdator {
 
-    public String update(String content, List<ContentUpdateCriteria> updates) {
-        return updates.stream()
-                .reduce(content,
-                        (currentContent, update) -> update(currentContent, update),
-                        (previous, last) -> last
-                );
-    }
 
-    private String update(String content, ContentUpdateCriteria update) {
-        StringBuffer result = new StringBuffer();
+    public String update(String content, ContentUpdateCriteria update) {
+        StringBuilder result = new StringBuilder();
         Matcher matcher = Pattern.compile(update.key()).matcher(content);
         while (matcher.find()) {
             String newValue;

--- a/src/main/java/io/github/yupd/infrastructure/update/updator/YamlPathUpdator.java
+++ b/src/main/java/io/github/yupd/infrastructure/update/updator/YamlPathUpdator.java
@@ -19,14 +19,11 @@ public class YamlPathUpdator {
     private static final ObjectMapper OBJECT_MAPPER = YamlObjectMapperFactory.create();
 
     public String update(String content, ContentUpdateCriteria yamlPathEntry) {
-        return update(content, List.of(yamlPathEntry));
-    }
-
-    public String update(String content, List<ContentUpdateCriteria> yamlPathEntries) {
         YamlExpressionParser yamlExpressionParser = YamlPath.from(content);
-        yamlPathEntries.forEach(entry -> yamlExpressionParser.write(entry.key(), entry.value()));
+        yamlExpressionParser.write(yamlPathEntry.key(), yamlPathEntry.value());
         return dumpAsString(yamlExpressionParser);
     }
+
 
     private String dumpAsString(YamlExpressionParser yaml) {
         return yaml.getResources().stream()

--- a/src/test/java/io/github/yupd/infrastructure/update/updator/RegexUpdatorTest.java
+++ b/src/test/java/io/github/yupd/infrastructure/update/updator/RegexUpdatorTest.java
@@ -3,7 +3,6 @@ package io.github.yupd.infrastructure.update.updator;
 import io.github.yupd.infrastructure.update.model.ContentUpdateCriteria;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -11,7 +10,7 @@ class RegexUpdatorTest {
 
     @Test
     void noMatch() {
-        List<ContentUpdateCriteria> criteria = List.of(new ContentUpdateCriteria("regex:(original contentt)", "titi"));
+        ContentUpdateCriteria criteria = new ContentUpdateCriteria("regex:(original contentt)", "titi");
 
         String result = new RegexUpdator().update("original content", criteria);
 
@@ -20,18 +19,17 @@ class RegexUpdatorTest {
 
     @Test
     void matchNoGroup() {
-        List<ContentUpdateCriteria> criteria = List.of(
-                new ContentUpdateCriteria("regex:oldname", "newname"),
-                new ContentUpdateCriteria("regex:name:", "newlabel:"));
-
-        String result = new RegexUpdator().update("name: oldname", criteria);
+        RegexUpdator updator = new RegexUpdator();
+        
+        String result = updator.update("name: oldname", new ContentUpdateCriteria("regex:oldname", "newname"));
+        result = updator.update(result, new ContentUpdateCriteria("regex:name:", "newlabel:"));
 
         assertThat(result).isEqualTo("newlabel: newname");
     }
 
     @Test
     void match() {
-        List<ContentUpdateCriteria> criteria = List.of(new ContentUpdateCriteria("regex:good name: ([a-z]+)", "newname"));
+        ContentUpdateCriteria criteria = new ContentUpdateCriteria("regex:good name: ([a-z]+)", "newname");
 
         String result = new RegexUpdator().update(
                 "1. should be updated -> good name: oldname\n" +


### PR DESCRIPTION
## Summary
- Refactored ContentUpdateService to process ContentUpdateCriteria in the order they appear in the list
- Updated both updators to expose single-update public methods
- Simplified code by removing unnecessary helper methods and filtering logic

## Changes
- **ContentUpdateService**: Uses stream with reduce to process updates sequentially instead of grouping by type
- **RegexUpdator**: Made single-update method public, removed List-based method
- **YamlPathUpdator**: Removed List-based method, kept single-update method
- **Tests**: Updated RegexUpdatorTest to use new API

## Test plan
- [x] All existing tests pass
- [x] Updates are now processed in the exact order of the input list
- [x] Both YAMLPATH and REGEX updates work correctly in sequence

🤖 Generated with [Claude Code](https://claude.ai/code)