### PR TITLE
Replace ContentUpdateCriteria constructor with factory method

### DIFF
--- a/src/main/java/io/github/yupd/business/YamlRepoUpdaterParameter.java
+++ b/src/main/java/io/github/yupd/business/YamlRepoUpdaterParameter.java
@@ -84,7 +84,7 @@ public class YamlRepoUpdaterParameter {
         }
 
         public Builder withContentUpdates(Map<String, String> yamlPathMap) {
-            withContentUpdates(yamlPathMap.entrySet().stream().map(ContentUpdateCriteria::new).collect(Collectors.toList()));
+            withContentUpdates(yamlPathMap.entrySet().stream().map(ContentUpdateCriteria::from).collect(Collectors.toList()));
             return this;
         }
 

--- a/src/main/java/io/github/yupd/infrastructure/update/model/ContentUpdateCriteria.java
+++ b/src/main/java/io/github/yupd/infrastructure/update/model/ContentUpdateCriteria.java
@@ -4,13 +4,13 @@ import java.util.Map;
 
 public record ContentUpdateCriteria(ContentUpdateType type, String key, String value) {
 
-    public ContentUpdateCriteria(String key, String value) {
-        this(ContentUpdateType.computeType(key),
-                key.replace(ContentUpdateType.computeType(key).getPrefix(), ""),
-                value);
+
+    public static ContentUpdateCriteria from(String key, String value) {
+        ContentUpdateType type = ContentUpdateType.computeType(key);
+        return new ContentUpdateCriteria(type, key.replace(type.getPrefix(), ""), value);
     }
 
-    public ContentUpdateCriteria(Map.Entry<String, String> entry) {
-        this(entry.getKey(), entry.getValue());
+    public static ContentUpdateCriteria from(Map.Entry<String, String> entry) {
+        return from(entry.getKey(), entry.getValue());
     }
 }

--- a/src/test/java/io/github/yupd/business/YamlRepoUpdaterTest.java
+++ b/src/test/java/io/github/yupd/business/YamlRepoUpdaterTest.java
@@ -64,7 +64,7 @@ class YamlRepoUpdaterTest {
         parameterBuilder = YamlRepoUpdaterParameter.builder()
                 .withTargetGitFile(gitFile)
                 .withMessage(COMMIT_MESSAGE)
-                .withContentUpdates(List.of(new ContentUpdateCriteria("ypath:path", "replacement")));
+                .withContentUpdates(List.of(ContentUpdateCriteria.from("ypath:path", "replacement")));
 
         lenient().when(uniqueIdGenerator.generate()).thenReturn("uniqueid");
     }

--- a/src/test/java/io/github/yupd/infrastructure/update/updator/RegexUpdatorTest.java
+++ b/src/test/java/io/github/yupd/infrastructure/update/updator/RegexUpdatorTest.java
@@ -10,7 +10,7 @@ class RegexUpdatorTest {
 
     @Test
     void noMatch() {
-        ContentUpdateCriteria criteria = new ContentUpdateCriteria("regex:(original contentt)", "titi");
+        ContentUpdateCriteria criteria = ContentUpdateCriteria.from("regex:(original contentt)", "titi");
 
         String result = new RegexUpdator().update("original content", criteria);
 
@@ -21,15 +21,15 @@ class RegexUpdatorTest {
     void matchNoGroup() {
         RegexUpdator updator = new RegexUpdator();
         
-        String result = updator.update("name: oldname", new ContentUpdateCriteria("regex:oldname", "newname"));
-        result = updator.update(result, new ContentUpdateCriteria("regex:name:", "newlabel:"));
+        String result = updator.update("name: oldname", ContentUpdateCriteria.from("regex:oldname", "newname"));
+        result = updator.update(result, ContentUpdateCriteria.from("regex:name:", "newlabel:"));
 
         assertThat(result).isEqualTo("newlabel: newname");
     }
 
     @Test
     void match() {
-        ContentUpdateCriteria criteria = new ContentUpdateCriteria("regex:good name: ([a-z]+)", "newname");
+        ContentUpdateCriteria criteria = ContentUpdateCriteria.from("regex:good name: ([a-z]+)", "newname");
 
         String result = new RegexUpdator().update(
                 "1. should be updated -> good name: oldname\n" +

--- a/src/test/java/io/github/yupd/infrastructure/update/updator/YamlPathUpdatorTest.java
+++ b/src/test/java/io/github/yupd/infrastructure/update/updator/YamlPathUpdatorTest.java
@@ -12,7 +12,7 @@ class YamlPathUpdatorTest {
     @Test
     public void testMonoDocument() {
         String content = IOUtils.readFile("YamlPathUpdator/deployment.yml");
-        String newContent = new YamlPathUpdator().update(content, new ContentUpdateCriteria("*.containers[0].image", "nginx:newversion"));
+        String newContent = new YamlPathUpdator().update(content, ContentUpdateCriteria.from("*.containers[0].image", "nginx:newversion"));
         String expected = IOUtils.readFile("YamlPathUpdator/deployment_expected.yml");
         assertThat(newContent).isEqualToIgnoringNewLines(expected);
     }
@@ -20,7 +20,7 @@ class YamlPathUpdatorTest {
     @Test
     public void testMultiDocument() {
         assertThat(
-                new YamlPathUpdator().update("name: oldContent\n---\nname: oldContent2", new ContentUpdateCriteria("name", "newContent")))
+                new YamlPathUpdator().update("name: oldContent\n---\nname: oldContent2", ContentUpdateCriteria.from("name", "newContent")))
                 .isEqualToIgnoringNewLines("name: newContent\n---\nname: newContent\n");
     }
 


### PR DESCRIPTION
## Summary
- Replaced the `ContentUpdateCriteria(String key, String value)` constructor with a static factory method `from(String key, String value)`
- Updated all code usages to use the new factory method approach
- Maintains backward compatibility in functionality while improving API clarity

## Changes
- **ContentUpdateCriteria**: Removed constructor, kept only static `from()` methods
- **YamlRepoUpdaterParameter**: Updated to use `ContentUpdateCriteria::from` method reference
- **Test classes**: Updated all instantiations to use factory method

## Benefits
- **Clearer intent**: Factory method name makes the creation process more explicit
- **Consistency**: All ContentUpdateCriteria creation now follows the same pattern
- **Better API design**: Static factory methods are preferred over constructors for complex object creation

## Test plan
- [x] All existing tests pass with new factory method
- [x] Functionality remains identical to previous constructor approach
- [x] No breaking changes to external APIs

🤖 Generated with [Claude Code](https://claude.ai/code)