### PR TITLE
fix: Add IOException reflection metadata for GraalVM native image

### DIFF
--- a/src/main/resources/reflection-config.json
+++ b/src/main/resources/reflection-config.json
@@ -511,5 +511,12 @@
     "allPublicMethods": true,
     "allDeclaredFields": true,
     "allPublicFields": true
+  },
+  {
+    "name": "java.io.IOException",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
   }
 ]


### PR DESCRIPTION
## Summary
- Fixes MissingReflectionRegistrationError for `java.io.IOException(String)` constructor in GraalVM native image
- Adds IOException to reflection-config.json with all constructors and methods enabled

## Test plan
- [ ] Build native image with `mvn package -Pnative`
- [ ] Verify IOException constructor can be accessed reflectively
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)